### PR TITLE
Release 6.1.1

### DIFF
--- a/src/Elders.Cronus.Persistence.Cassandra/Cronus.Persistence.Cassandra.rn.md
+++ b/src/Elders.Cronus.Persistence.Cassandra/Cronus.Persistence.Cassandra.rn.md
@@ -1,5 +1,6 @@
 #### 6.1.1 - 24.09.2020
 * Starts using GetSession from CassandraProvider instead of local copies for connections
+* Updates Cronus package to 6.1.1
 
 #### 6.1.0 - 24.08.2020
 * Updates packages

--- a/src/Elders.Cronus.Persistence.Cassandra/Cronus.Persistence.Cassandra.rn.md
+++ b/src/Elders.Cronus.Persistence.Cassandra/Cronus.Persistence.Cassandra.rn.md
@@ -1,3 +1,6 @@
+#### 6.1.1 - 24.09.2020
+* Starts using GetSession from CassandraProvider instead of local copies for connections
+
 #### 6.1.0 - 24.08.2020
 * Updates packages
 

--- a/src/Elders.Cronus.Persistence.Cassandra/Elders.Cronus.Persistence.Cassandra.csproj
+++ b/src/Elders.Cronus.Persistence.Cassandra/Elders.Cronus.Persistence.Cassandra.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cronus" Version="6.1.0" />
+    <PackageReference Include="Cronus" Version="6.1.1" />
     <PackageReference Include="CassandraCSharpDriver" Version="3.15.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.7" />
   </ItemGroup>

--- a/src/Elders.Cronus.Persistence.Cassandra/IndexByEventTypeStore.cs
+++ b/src/Elders.Cronus.Persistence.Cassandra/IndexByEventTypeStore.cs
@@ -13,24 +13,26 @@ namespace Elders.Cronus.Persistence.Cassandra
         private const string Read = @"SELECT aid FROM index_by_eventtype WHERE et = ?;";
         private const string Write = @"INSERT INTO index_by_eventtype (et,aid) VALUES (?,?);";
 
-        private readonly ISession session;
+        private readonly ICassandraProvider cassandraProvider;
+
+        private ISession GetSession() => cassandraProvider.GetSession(); // In order to keep only 1 session alive (https://docs.datastax.com/en/developer/csharp-driver/3.16/faq/)
 
         public IndexByEventTypeStore(ICassandraProvider cassandraProvider)
         {
             if (cassandraProvider is null) throw new ArgumentNullException(nameof(cassandraProvider));
 
-            this.session = cassandraProvider.GetSession();
+            this.cassandraProvider = cassandraProvider;
         }
 
         public void Apend(IEnumerable<IndexRecord> indexRecords)
         {
             try
             {
-                PreparedStatement statement = session.Prepare(Write);
+                PreparedStatement statement = GetSession().Prepare(Write);
 
                 foreach (var record in indexRecords)
                 {
-                    session.Execute(statement.Bind(record.Id, Convert.ToBase64String(record.AggregateRootId)));
+                    GetSession().Execute(statement.Bind(record.Id, Convert.ToBase64String(record.AggregateRootId)));
                 }
 
             }
@@ -43,8 +45,8 @@ namespace Elders.Cronus.Persistence.Cassandra
         public IEnumerable<IndexRecord> Get(string indexRecordId)
         {
             List<IndexRecord> indexRecords = new List<IndexRecord>();
-            BoundStatement bs = session.Prepare(Read).Bind(indexRecordId);
-            var result = session.Execute(bs);
+            BoundStatement bs = GetSession().Prepare(Read).Bind(indexRecordId);
+            var result = GetSession().Execute(bs);
             foreach (var row in result.GetRows())
             {
                 yield return new IndexRecord(indexRecordId, Convert.FromBase64String(row.GetValue<string>("aid")));


### PR DESCRIPTION
# Title
Starts using GetSession from CassandraProvider instead of local copies for connections

## Related Issue 
No related issue

### Description
In the multiple files where ISession was being used, under specific circumstances the session could time-out or get disposed. The sessions are managed by the CassandraProvider implementation, which is singletonPerTenant. All classes that used ISession directly now use the CassandraProvider in order to have their session resolved.

### Test Methods
This specific version has not been tested. Please advise on how to test